### PR TITLE
fix: `uri._rootUri` is sometimes placed under `uri.rootUri`

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,8 +41,9 @@ export function activate(context: vscode.ExtensionContext) {
                 let outputType = vscode.workspace.getConfiguration().get('gitmoji.outputType');
 
                 if (uri) {
+                    const uriPath = uri._rootUri?.path || uri.rootUri.path;
                     let selectedRepository = git.repositories.find(repository => {
-                        return repository.rootUri.path === uri._rootUri.path;
+                        return repository.rootUri.path === uriPath;
                     });
                     if (selectedRepository) {
                         if (outputType === 'emoji') {


### PR DESCRIPTION
Hello @seatonjiang .

I noticed a bug in my VSCode Insiders v1.74 where `uri._rootUri` is undefined when using the emoji button under Source Control, which makes the extension throw `Cannot read properties of undefined (reading 'path')` when I select an emoji. It is the same whether I use `Source Control Repositories` or `Source Control`.

However, when I use the command (`cmd+shift+p` -> `Choose gitmoji`) it works as usual.

This is the fix I could come up with, but there might be a better way to do it, or some other issue I'm missing. I'm not sure why `uri` is different when launching via the emoji button vs the vscode command.

My current VSCode configuration:
```
Version: 1.74.0-insider
Commit: 5235c6bb189b60b01b1f49062f4ffa42384f8c91
Date: 2022-12-05T10:16:10.754Z (1 day ago)
Electron: 19.1.8
Chromium: 102.0.5005.167
Node.js: 16.14.2
V8: 10.2.154.15-electron.0
OS: Darwin arm64 21.6.0
Sandboxed: Yes
```


https://user-images.githubusercontent.com/60484937/206133675-c56c877c-04bf-4acd-91a4-188ab33575ef.mov



