### PR TITLE
new feature ✨

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "gitmoji-vscode-test",
+    "name": "gitmoji-vscode",
     "displayName": "Gitmoji",
     "description": "Gitmoji tool for git commit messages in VSCode",
     "version": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "gitmoji-vscode",
+    "name": "gitmoji-vscode-test",
     "displayName": "Gitmoji",
     "description": "Gitmoji tool for git commit messages in VSCode",
     "version": "1.2.5",
@@ -103,6 +103,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "%gitmoji.config.asSuffix%"
+                },
+                "gitmoji.autoMatch": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether to enable auto-matching emoji based on commit message"
                 }
             }
         }


### PR DESCRIPTION
This PR introduces a new feature that suggests Gitmoji emojis based on the user's commit message content.

Feature Details:
Users can now type their commit comment first in the SCM input box.

When the Gitmoji emoji list is opened, the extension will analyze the comment and prioritize emoji suggestions that match the content.

A new configuration option is added: gitmoji.enableAutoMatch

Type: boolean

Default: false

When enabled, auto-matching is triggered.

![屏幕截图 2025-05-12 113444](https://github.com/user-attachments/assets/86f2cc62-4ecb-4118-be16-2de6f2a3c4e6)

The feature has been tested locally and works as expected.

Backward-compatible: if enableAutoMatch is not enabled, the extension behaves the same as before.